### PR TITLE
Team grid

### DIFF
--- a/src/components/teamMemberCard.js
+++ b/src/components/teamMemberCard.js
@@ -3,12 +3,12 @@ import Card from './Card'
 
 const teamMemberCard = ({ teamMember }) => (
   <Card className="mb-8">
-    <p className="text-xl font-semibold">
+    <p className="text-l font-semibold">
       <a href={teamMember.github} target="new">
         {teamMember.title}
       </a>
     </p>
-    <p className="mt-6">{teamMember.content}</p>
+    <p className="mt-6">{teamMember.summary}</p>
     <div className="flex items-center mt-8">
       <img
         className="w-12 h-12 mr-4 rounded-full"

--- a/src/data/team-data.js
+++ b/src/data/team-data.js
@@ -2,11 +2,13 @@ export default [
   {
     title: 'John Favorite',
     github: 'https://github.com/OldCrowEW',
+    summary: 'John Favourite is the ...',
     content: 'John Favourite is the ...',
   },
   {
     title: 'Jonathan Meyers',
     github: 'https://github.com/jmymy',
+    summary: 'Jonathan Meyers is the Head of Infrastructure at Cybrary',
     content:
       'Jonathan Meyers is the Head of Infrastructure at Cybrary where he is responsible for designing, maintaining, and securing all corporate infrastructure including their Security Enablement platform supporting over 200 companies and 2.5 million users worldwide. He previously worked as a Senior DevOps and Senior Operations Engineer at Forcepoint (formally RedOwl Analytics prior to their acquisition) where he oversaw the operations and deployment of their hosted and on-prem UEBA/E-Surveillance product. Jonathan holds an Information Technology degree from The United States Military Academy at West Point.',
     teamMemberImage: 'https://placeimg.com/150/150/people',
@@ -14,17 +16,21 @@ export default [
   {
     title: 'James Collins',
     github: 'https://github.com/jracollins',
+    summary: 'James Collins is the ...',
     content: 'James Collins is the ...',
   },
   {
     title: 'Wayne Pascoe',
     github: 'https://github.com/WTPascoe',
+    summary:
+      'Wayne Pascoe is the head of DevOps for an external customer facing product team at J.P. Morgan and has worked in DevOps at a number of large financial services institutions as well as smaller more agile companies.',
     content:
       'Wayne Pascoe is the head of DevOps for an external customer facing product team at J.P. Morgan responsible for modernising the platform and processes to deliver a SaaS product. He is also responsible for developing the support operating model for a number of institutional clients external to the company. Before this, Wayne worked as a Senior Engineer and Head of DevOps at Beacon Platform and was responsible for client deployments and support in both cloud and on-premises environments. He was also a key part of the team that implemented processes, controls, and reporting to achieve SOC 1 and SOC 2 attestation. Wayne brings a wealth of knowledge and experience from working in some of the world’s largest banks and exciting start-ups.',
     teamMemberImage: 'https://placeimg.com/150/150/people',
   },
   {
     title: 'Stephen Drollinger',
+    summary: 'Stephen Drollinger is the ...',
     content: 'Stephen Drollinger is the ...',
   },
 ]

--- a/src/data/team-data.js
+++ b/src/data/team-data.js
@@ -2,13 +2,14 @@ export default [
   {
     title: 'John Favorite',
     github: 'https://github.com/OldCrowEW',
-    summary: 'John Favourite is the ...',
-    content: 'John Favourite is the ...',
+    summary: 'John Favourite is ...',
+    content: 'John Favourite is ...',
   },
   {
     title: 'Jonathan Meyers',
     github: 'https://github.com/jmymy',
-    summary: 'Jonathan Meyers is the Head of Infrastructure at Cybrary',
+    summary:
+      'Jonathan Meyers is the Head of Infrastructure at Cybrary where he is responsible for designing, maintaining, and securing all corporate infrastructure including their Security Enablement platform.',
     content:
       'Jonathan Meyers is the Head of Infrastructure at Cybrary where he is responsible for designing, maintaining, and securing all corporate infrastructure including their Security Enablement platform supporting over 200 companies and 2.5 million users worldwide. He previously worked as a Senior DevOps and Senior Operations Engineer at Forcepoint (formally RedOwl Analytics prior to their acquisition) where he oversaw the operations and deployment of their hosted and on-prem UEBA/E-Surveillance product. Jonathan holds an Information Technology degree from The United States Military Academy at West Point.',
     teamMemberImage: 'https://placeimg.com/150/150/people',
@@ -16,8 +17,8 @@ export default [
   {
     title: 'James Collins',
     github: 'https://github.com/jracollins',
-    summary: 'James Collins is the ...',
-    content: 'James Collins is the ...',
+    summary: 'James Collins is ...',
+    content: 'James Collins is ...',
   },
   {
     title: 'Wayne Pascoe',
@@ -30,7 +31,7 @@ export default [
   },
   {
     title: 'Stephen Drollinger',
-    summary: 'Stephen Drollinger is the ...',
-    content: 'Stephen Drollinger is the ...',
+    summary: 'Stephen Drollinger is ...',
+    content: 'Stephen Drollinger is ...',
   },
 ]

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -68,9 +68,12 @@ export default () => (
     <section id="yourteam" className="py-20 lg:pb-40 lg:pt-48">
       <div className="container mx-auto text-center">
         <h2 className="text-3xl lg:text-5xl font-semibold">Meet Your Team</h2>
-        <div className="flex flex-col md:flex-row md:-mx-3">
+        <div className="flex flex-row flex-wrap">
           {teamData.map(teamMember => (
-            <div key={teamMember.teamMemberName} className="flex-1 px-3">
+            <div
+              key={teamMember.teamMemberName}
+              className="flex-auto px-3 lg:w-1/2 md:w-full sm:w-full xs:w-full"
+            >
               <TeamCard teamMember={teamMember} />
             </div>
           ))}


### PR DESCRIPTION
Make team info max 2 columns on page, but still flow down to 1 on smaller screens.