### PR TITLE
feat: add Microsoft domain verification file

### DIFF
--- a/public/.well-known/microsoft-identity-association.json
+++ b/public/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "54c3afe6-4430-4580-b458-20331ce513bc"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.well-known/microsoft-identity-association.json` to verify `doneops.com` as a publisher domain for the TIN application (app ID: `54c3afe6-4430-4580-b458-20331ce513bc`)

## Test plan
- [ ] Verify the file is accessible at `https://doneops.com/.well-known/microsoft-identity-association.json` after deploy
- [ ] Click "Verify and save domain" in the Microsoft portal to confirm verification succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)